### PR TITLE
Fix UI Overlap Between AudioVisualizer and Transcription Status

### DIFF
--- a/src/components/DictationProcessor.tsx
+++ b/src/components/DictationProcessor.tsx
@@ -72,14 +72,14 @@ export function DictationProcessor() {
       <div className="space-y-3 relative">
         <div className="flex justify-between items-center pl-1 h-6">
           <label className="text-sm font-medium text-foreground/80">Transcription</label>
-          {isRecording && (
-            <div className="absolute right-0 top-0 flex items-center">
+          <div className="flex items-center gap-4">
+            {isRecording && (
               <AudioVisualizer stream={audioStream} isRecording={isRecording} width={100} height={30} />
-            </div>
-          )}
-          {isTranscribing && (
-            <span className="text-xs text-primary animate-pulse">Transcribing...</span>
-          )}
+            )}
+            {isTranscribing && (
+              <span className="text-xs text-primary animate-pulse font-medium">Transcribing...</span>
+            )}
+          </div>
         </div>
         <DictationInput
           value={inputText}


### PR DESCRIPTION
# Fixes: #1 

## Title

Fix UI Overlap Between AudioVisualizer and Transcription Status

---

## Summary

This PR resolves a UI overlap issue that occurred during active transcription, where the `AudioVisualizer` and the “Transcribing…” status text were rendered on top of each other. The issue made the transcription state difficult to read and 

## What Changed

* **Refactored Layout Logic**
  Removed absolute positioning from the `AudioVisualizer`, which was causing it to sit on top of the transcription status text.

* **Unified Flexbox Container**
  Grouped the `AudioVisualizer` and the “Transcribing…” status into a single flex container with `gap-4`, ensuring consistent spacing and predictable layout behavior.

* **Improved Visual Hierarchy**
  Added `font-medium` to the transcription status text so it maintains appropriate visual weight alongside the visualizer.

---

## Result

* The waveform visualizer and transcription status now render **side-by-side** on the right side of the “Transcription” header.
* No UI elements overlap during transcription.
* The interface is clearer and easier to read while audio is being processed.

---

## Verification

* Manually verified during active transcription.
* Confirmed via a successful production build.


